### PR TITLE
fixing memory leaks plus assertion errors from gmime

### DIFF
--- a/gmime/envelope.go
+++ b/gmime/envelope.go
@@ -240,7 +240,7 @@ func (m *Envelope) Header(header string) string {
 // ContentType returns envelope's content-type
 func (m *Envelope) ContentType() string {
 	mimePart := C.g_mime_message_get_mime_part(m.gmimeMessage)
-	if mimePart != nil && !gobool(C.gmime_is_content_type(mimePart)) {
+	if mimePart != nil {
 		ctype := C.gmime_get_content_type_string(mimePart)
 		defer C.g_free(C.gpointer(unsafe.Pointer(ctype)))
 		return C.GoString(ctype)

--- a/gmime/gmime.c
+++ b/gmime/gmime.c
@@ -34,6 +34,14 @@ gboolean gmime_is_multi_part (GMimeObject *object) {
 	return GMIME_IS_MULTIPART (object);
 }
 
+gboolean gmime_is_part (GMimeObject *object) {
+	return GMIME_IS_PART (object);
+}
+
+gboolean gmime_is_content_type (GMimeObject *object) {
+	return GMIME_IS_CONTENT_TYPE (object);
+}
+
 void gmime_type_name(GMimeObject *object){
 	printf("Name: %s\n", G_OBJECT_TYPE_NAME (object));
 }

--- a/gmime/gmime.h
+++ b/gmime/gmime.h
@@ -6,6 +6,8 @@ GMimeMessage *gmime_parse (const char *buffer, size_t len);
 char* gmime_get_content_string (GMimeObject *object);
 char* gmime_get_content_type_string (GMimeObject *object);
 gboolean gmime_is_multi_part (GMimeObject *object);
+gboolean gmime_is_part (GMimeObject *object);
 gboolean gmime_is_text_part (GMimeObject *object);
+gboolean gmime_is_content_type (GMimeObject *object);
 void gmime_type_name(GMimeObject *object);
 GByteArray *gmime_get_bytes (GMimeObject *object);

--- a/gmime/part.go
+++ b/gmime/part.go
@@ -31,7 +31,10 @@ func (p *Part) IsText() bool {
 
 // IsAttachment returns true if part's mime is attachment or inline attachment
 func (p *Part) IsAttachment() bool {
-	if gobool(C.gmime_is_multi_part(p.gmimePart)) {
+	if p.gmimePart == nil {
+		return false
+	}
+	if !gobool(C.gmime_is_part(p.gmimePart)) || gobool(C.gmime_is_multi_part(p.gmimePart)) {
 		return false
 	}
 	if gobool(C.g_mime_part_is_attachment((*C.GMimePart)(unsafe.Pointer(p.gmimePart)))) {
@@ -46,6 +49,12 @@ func (p *Part) IsAttachment() bool {
 
 // Filename retrieves the filename of the part
 func (p *Part) Filename() string {
+	if p.gmimePart == nil {
+		return ""
+	}
+	if !gobool(C.gmime_is_part(p.gmimePart)) {
+		return ""
+	}
 	ctype := C.g_mime_part_get_filename((*C.GMimePart)(unsafe.Pointer(p.gmimePart)))
 	return C.GoString(ctype)
 }


### PR DESCRIPTION
Fixing memory leak caused by not freeing InternetAddressList https://github.com/GNOME/gmime/blob/76803415b82e62dbccdc26abbd06a1517d11b4f2/gmime/internet-address.c#L2132

pre-checking object types so type check does not fail in gmime