### PR TITLE
fix content id memory #patch

### DIFF
--- a/gmime/gmime_test.go
+++ b/gmime/gmime_test.go
@@ -574,6 +574,27 @@ func TestAppendAddressList(t *testing.T) {
 	}
 }
 
+// TestPart_ContentID not only tests the function fetches content-id correctly,
+// but it also makes sure there is no crash when the envelope is closed (since we have seen a bug around this)
+func TestPart_ContentID(t *testing.T) {
+	mimeBytes, err := ioutil.ReadFile(`test_data/attachment-content-id.eml`)
+	assert.NoError(t, err)
+	msg, err := Parse(string(mimeBytes))
+	assert.NoError(t, err)
+
+	actual := ""
+	expected := `f_l0eugokh0`
+	err = msg.Walk(func(p *Part) error {
+		if p.IsAttachment() {
+			actual = p.ContentID()
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+	msg.Close()
+}
+
 func TestPart_String(t *testing.T) {
 	type TestCase struct {
 		filename string

--- a/gmime/part.go
+++ b/gmime/part.go
@@ -113,7 +113,6 @@ func (p *Part) ContentID() string {
 		return ""
 	}
 	cCID := C.g_mime_object_get_content_id(p.gmimePart)
-	defer C.g_free(C.gpointer(unsafe.Pointer(cCID)))
 	return C.GoString(cCID)
 }
 

--- a/gmime/test_data/attachment-content-id.eml
+++ b/gmime/test_data/attachment-content-id.eml
@@ -1,0 +1,43 @@
+MIME-Version: 1.0
+Date: Sat, 5 Mar 2022 21:39:05 -0800
+Message-ID: <CAFWNCUNV0+_GyxffZmKeMG=qh=T+EAMcU0YtNGskL_Ad0uVPcw@mail.gmail.com>
+Subject: Test with content id
+From: Eric Choi <echoi@twilio.com>
+To: Eric Choi <echoi@twilio.com>
+Content-Type: multipart/mixed; boundary="0000000000008febcf05d9862a4c"
+
+--0000000000008febcf05d9862a4c
+Content-Type: multipart/alternative; boundary="0000000000008febcd05d9862a4a"
+
+--0000000000008febcd05d9862a4a
+Content-Type: text/plain; charset="UTF-8"
+
+Test with content ID
+
+--
+
+Eric Choi
+Staff, Software Engineer (L4) | Email Infrastructure - Teapot
+
+--0000000000008febcd05d9862a4a
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+<div dir=3D"ltr">Test with content ID<br clear=3D"all"><div><br></div>-- <b=
+r><div dir=3D"ltr" class=3D"gmail_signature" data-smartmail=3D"gmail_signat=
+ure"><div dir=3D"ltr"><div><div dir=3D"ltr"><img src=3D"https://sendgrid.co=
+m/brand/sg-twilio/SG_Twilio_Lockup_RGBx1.png" width=3D"96" height=3D"21"><b=
+r><div>Eric Choi</div><div><div>Staff, Software Engineer (L4) | Email Infra=
+structure - Teapot</div></div><div><br></div><div><br></div></div></div></d=
+iv></div></div>
+
+--0000000000008febcd05d9862a4a--
+--0000000000008febcf05d9862a4c
+Content-Type: image/png; name="4854118-kirby_with_shades_render_by_torzk-d5rliq1.png"
+Content-Disposition: attachment; filename="4854118-kirby_with_shades_render_by_torzk-d5rliq1.png"
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_l0eugokh0
+Content-ID: <f_l0eugokh0>
+
+
+--0000000000008febcf05d9862a4c--


### PR DESCRIPTION
- What
  - fix a memory issue with content-id
  
- Why
  - ContentID() was freeing const char* that should never be freed; it was leading to a crash when envelope was closed
  - 
https://github.com/jstedfast/gmime#understanding-memory-management-in-gmime

## PR - Merge Checklist
- [x] Workflow: Title has [semver](http://semver.org/) bump level defined (#major, #minor, or #patch)
- [x] README updated or N/A
- [x] Dependencies satisfied or N/A {db-schema,upstream repos,chef,config,hardware,ops - Add bullet points with links to corresponding PRs/tickets}

## Dependencies
- [x] {db-schema/db,upstream repos —> integration - Add bullet points with links to corresponding PRs/tickets}