### PR TITLE
add content type param #minor

### DIFF
--- a/gmime/envelope.go
+++ b/gmime/envelope.go
@@ -36,6 +36,7 @@ func Parse(data string) (*Envelope, error) {
 }
 
 // Subject returns envelope's Subject
+// gmime returns the string in utf-8
 func (m *Envelope) Subject() string {
 	subject := C.g_mime_message_get_subject(m.gmimeMessage)
 	return C.GoString(subject)

--- a/gmime/part.go
+++ b/gmime/part.go
@@ -25,6 +25,13 @@ func (p *Part) ContentType() string {
 	return C.GoString(ctype)
 }
 
+// ContentTypeWithParam returns content type's parameter
+func (p *Part) ContentTypeWithParam(param string) string {
+	ctype := C.g_mime_object_get_content_type(p.gmimePart)
+	charset := C.g_mime_content_type_get_parameter(ctype, C.CString(param))
+	return C.GoString(charset)
+}
+
 // IsText returns true if part's mime is text/*
 func (p *Part) IsText() bool {
 	return gobool(C.gmime_is_text_part(p.gmimePart))


### PR DESCRIPTION
- What
  - add ContentTypeWithParam method to part

- Why
need a way to get charset from content-type

## PR - Merge Checklist
- [x] Workflow: Title has [semver](http://semver.org/) bump level defined (#major, #minor, or #patch)
- [x] README updated or N/A
- [x] Dependencies satisfied or N/A {db-schema,upstream repos,chef,config,hardware,ops - Add bullet points with links to corresponding PRs/tickets}

## Dependencies
- [x] {db-schema/db,upstream repos —> integration - Add bullet points with links to corresponding PRs/tickets}